### PR TITLE
change highlighter to rouge to stop github page warning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ url: "http://dmlc.ml"
 
 # Build settings
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 
 redcarpet:
   extensions: ["fenced_code_blocks", "no_intra_emphasis", "tables", "autolink", "strikethrough", "with_toc_data"]


### PR DESCRIPTION
After a new post is merged, I received an email from github:

> The page build completed successfully, but returned the following warning for the `master` branch:
> 
> You are attempting to use the 'pygments' highlighter, which is currently unsupported on GitHub Pages. Your site will use 'rouge' for highlighting instead. To suppress this warning, change the 'highlighter' value to 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset. For more information, see https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors.
> 
> For information on troubleshooting Jekyll see:
>
>   https://help.github.com/articles/troubleshooting-jekyll-builds
> 
> If you have any questions you can contact us by replying to this email.

According to https://help.github.com/articles/page-build-failed-config-file-error/#fixing-highlighting-errors, the  parameter `highlighter` can only be set to `rouge`.