### PR TITLE
move to dmlc.io instead of ml

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-dmlc.ml
+dmlc.io


### PR DESCRIPTION
move away from the not reliable .ml domain register